### PR TITLE
fix: android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,7 +130,7 @@ dependencies {
   // From node_modules
 
   // Openpath Mobile Access Core SDK
-  compileOnly fileTree(dir: "libs", include: ["*.aar"]) // Openpath Mobile Access Core SDK Dependencies
+  implementation fileTree(dir: 'libs', include: ['*.aar'])
   implementation 'com.madgag.spongycastle:core:1.54.0.0'
   implementation 'com.madgag.spongycastle:prov:1.54.0.0'
   implementation 'com.madgag.spongycastle:pkix:1.54.0.0'


### PR DESCRIPTION
compileOnly makes the runtime unable import the library

I've changed it to implementation and I've tested it that build and runtime ok